### PR TITLE
[ci] Bump php versions for phpunit and minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
- 
+  - 7.2
+  - 7.4
+
 env:
   matrix:
     - COMPOSER_FLAGS="--prefer-lowest"

--- a/tests/SearchAndReplaceTest.php
+++ b/tests/SearchAndReplaceTest.php
@@ -10,7 +10,7 @@ class SearchAndReplaceTest extends TestCase
     /** @var \Awssat\TailwindShift\SearchAndReplace */
     protected $searchAndReplace;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         //TODO: phpUnit 8 incompatibility, void error.
         $this->searchAndReplace = new searchAndReplace();
@@ -21,10 +21,11 @@ class SearchAndReplaceTest extends TestCase
     {
         $this->searchAndReplace
         ->setContent('<tag class="life-is-sad"></tag>')
-        ->perform('{regex_string}-{regex_string}-sad',
-                '{regex_string}-{regex_string}-fun',
-                SearchAndReplace::INSIDE_CLASSE_PROP
-            );
+        ->perform(
+            '{regex_string}-{regex_string}-sad',
+            '{regex_string}-{regex_string}-fun',
+            SearchAndReplace::INSIDE_CLASSE_PROP
+        );
 
         $this->assertEquals(
             '<tag class="life-is-fun"></tag>',
@@ -37,10 +38,11 @@ class SearchAndReplaceTest extends TestCase
     {
         $this->searchAndReplace
         ->setContent('<tag class="life-is-sad"></tag>')
-        ->perform('life-is-{regex_string}',
-                '{regex_string}-is-{regex_string}',
-                SearchAndReplace::INSIDE_CLASSE_PROP
-            );
+        ->perform(
+            'life-is-{regex_string}',
+            '{regex_string}-is-{regex_string}',
+            SearchAndReplace::INSIDE_CLASSE_PROP
+        );
 
         $this->assertEquals(
             '<tag class="sad-is-sad"></tag>',

--- a/tests/UpdaterTest.php
+++ b/tests/UpdaterTest.php
@@ -10,7 +10,7 @@ class UpdaterTest extends TestCase
     /** @var \Awssat\TailwindShift\Updater */
     protected $updater;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         //TODO: phpUnit 8 incompatibility, void error.
         $this->updater = new Updater();
@@ -42,7 +42,7 @@ class UpdaterTest extends TestCase
     /** @test */
     public function it_convert_multiline_classes()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             'border-teal-500',
             $this->updater->setContent('<component
             class="group cursor-pointer bg-grey-dark"
@@ -56,7 +56,7 @@ class UpdaterTest extends TestCase
     /** @test */
     public function it_convert_class_content_only()
     {
-        $this->assertContains(
+        $this->assertStringContainsString(
             'http://www.w3.org/2000/svg',
             $this->updater->setContent('<svg class="fill-current h-6 w-6" xmlns="http://www.w3.org/2000/svg"')->convert()->get()
         );
@@ -72,17 +72,17 @@ class UpdaterTest extends TestCase
 
         $convertedCode = $this->updater->setContent($code)->convert()->get();
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '{{ Auth::user()->name }}',
             $convertedCode
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Selected: ',
             $convertedCode
         );
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             '<button-orange>',
             $convertedCode
         );


### PR DESCRIPTION
The error shown in Travis was:

This version of PHPUnit is supported on PHP 7.2 and PHP 7.3.
You are using PHP 7.1.27 (/home/travis/.phpenv/versions/7.1.27/bin/php).
The command "phpunit --coverage-clover clover" exited with 1.